### PR TITLE
Fix Client Context propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Supported releases and dependencies are shown below.
 
 | kamon-http4s  | status | jdk  | scala | http4s            
 |:------:|:------:|:----:|--------------:|-------
-|  1.0.5 | stable | 1.8+ | 2.11, 2.12 | 0.18.x
+|  1.0.7 | stable | 1.8+ | 2.11, 2.12 | 0.18.x
 
 To get started with SBT, simply add the following to your `build.sbt`
 file:
 
 ```scala
-libraryDependencies += "io.kamon" %% "kamon-http4s" % "1.0.5"
+libraryDependencies += "io.kamon" %% "kamon-http4s" % "1.0.7"
 ```
 
 ## Metrics and Tracing for http4s in 2 steps
@@ -62,12 +62,12 @@ object GoogleService {
 ### Step 1: Add the Kamon Libraries
 ```scala
 libraryDependencies ++= Seq(
-  "io.kamon" %% "kamon-core" % "1.0.1",
+  "io.kamon" %% "kamon-core" % "1.1.2",
   "io.kamon" %% "kamon-system-metrics" % "1.0.1",
   "io.kamon" %% "kamon-prometheus" % "1.0.0",
-  "io.kamon" %% "kamon-http4s" % "1.0.5",
+  "io.kamon" %% "kamon-http4s" % "1.0.7",
   "io.kamon" %% "kamon-zipkin" % "1.0.1",
-  "io.kamon" %% "kamon-jaeger" % "1.0.1"
+  "io.kamon" %% "kamon-jaeger" % "1.0.2"
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,19 +13,19 @@
  * =========================================================================================
  */
 
-val kamonCore         = "io.kamon"    %% "kamon-core"             % "1.1.0"
-val kamonTestkit      = "io.kamon"    %% "kamon-testkit"          % "1.1.0"
+val kamonCore         = "io.kamon"    %% "kamon-core"             % "1.1.2"
+val kamonTestkit      = "io.kamon"    %% "kamon-testkit"          % "1.1.2"
 
-val server            = "org.http4s"  %%  "http4s-blaze-server"   % "0.18.2"
-val client            = "org.http4s"  %%  "http4s-blaze-client"   % "0.18.2"
-val dsl               = "org.http4s"  %%  "http4s-dsl"            % "0.18.2"
+val server            = "org.http4s"  %%  "http4s-blaze-server"   % "0.18.8"
+val client            = "org.http4s"  %%  "http4s-blaze-client"   % "0.18.8"
+val dsl               = "org.http4s"  %%  "http4s-dsl"            % "0.18.8"
 
 
 lazy val root = (project in file("."))
   .settings(Seq(
       name := "kamon-http4s",
-      scalaVersion := "2.12.4",
-      crossScalaVersions := Seq("2.11.12", "2.12.4")))
+      scalaVersion := "2.12.5",
+      crossScalaVersions := Seq("2.11.12", "2.12.5")))
   .settings(resolvers += Resolver.bintrayRepo("kamon-io", "snapshots"))
   .settings(resolvers += Resolver.mavenLocal)
   .settings(scalacOptions ++= Seq("-Ypartial-unification", "-language:higherKinds"))

--- a/src/main/scala/kamon/http4s/middleware/client/KamonSupport.scala
+++ b/src/main/scala/kamon/http4s/middleware/client/KamonSupport.scala
@@ -40,8 +40,7 @@ object KamonSupport {
     for {
       ctx <- F.delay(Kamon.currentContext())
       clientSpan <- F.delay(ctx.get(Span.ContextKey))
-      k <- if (clientSpan.isEmpty()) service(request)
-           else kamonService(service)(request)(clientSpan)(ctx)
+      k <- kamonService(service)(request)(clientSpan)(ctx)
       } yield k
   }
 
@@ -98,7 +97,7 @@ object KamonSupport {
         .asChildOf(clientSpan)
         .withMetricTag("span.kind", "client")
         .withMetricTag("component", "http4s.client")
-        .withTag("http.method", request.method.name)
+        .withMetricTag("http.method", request.method.name)
         .withTag("http.url", request.uri.renderString))
     } yield spanBuilder
 }

--- a/src/main/scala/kamon/http4s/middleware/server/KamonSupport.scala
+++ b/src/main/scala/kamon/http4s/middleware/server/KamonSupport.scala
@@ -50,8 +50,8 @@ object KamonSupport {
       _ <- F.delay(serviceMetrics.generalMetrics.activeRequests.increment())
       scope <- F.delay(Kamon.storeContext(incomingContext.withKey(Span.ContextKey, serverSpan)))
       e <- service(request).value.attempt
-      _ <- F.delay(scope.close())
       resp <- kamonServiceHandler(request.method, now, serviceMetrics, serverSpan, e)
+      _ <- F.delay(scope.close())
     } yield resp
   }
 
@@ -108,7 +108,7 @@ object KamonSupport {
         .asChildOf(incomingContext.get(Span.ContextKey))
         .withMetricTag("span.kind", "server")
         .withMetricTag("component", "http4s.server")
-        .withTag("http.method", request.method.name)
+        .withMetricTag("http.method", request.method.name)
         .withTag("http.url", request.uri.renderString)
         .start())
     } yield serverSpan


### PR DESCRIPTION
* context should be propagated all the time although the span does not exist
* adding component as a metric tag instead of just span tag
* uptate to http4s 0.18.8
* uptate to kamon 1.1.2
