### PR TITLE
Keep scope open for responseHandler

### DIFF
--- a/src/main/scala/kamon/http4s/middleware/client/KamonSupport.scala
+++ b/src/main/scala/kamon/http4s/middleware/client/KamonSupport.scala
@@ -56,7 +56,6 @@ object KamonSupport {
       scope <- F.delay(Kamon.storeContext(newCtx))
       encodedRequest <- encodeContext(newCtx)(request)
       result <- service(encodedRequest).attempt
-      _ <- F.delay(scope.close())
       response <- result match {
         case Left(e) => F
             .delay(span.finish())
@@ -64,6 +63,7 @@ object KamonSupport {
         case Right(response) => F.pure(response)
       }
       _ <- responseHandler(span, response)
+      _ <- F.delay(scope.close())
     } yield response
 
   private def newContext[F[_]](ctx: Context, span: Span)

--- a/src/main/scala/kamon/http4s/middleware/server/KamonSupport.scala
+++ b/src/main/scala/kamon/http4s/middleware/server/KamonSupport.scala
@@ -50,8 +50,8 @@ object KamonSupport {
       _ <- F.delay(serviceMetrics.generalMetrics.activeRequests.increment())
       scope <- F.delay(Kamon.storeContext(incomingContext.withKey(Span.ContextKey, serverSpan)))
       e <- service(request).value.attempt
-      _ <- F.delay(scope.close())
       resp <- kamonServiceHandler(request.method, now, serviceMetrics, serverSpan, e)
+      _ <- F.delay(scope.close())
     } yield resp
   }
 


### PR DESCRIPTION
We are trying to fix an issue with traceIDs exposed in this project https://github.com/ptrlaszlo/kamon-http4s-traceId-test
It looks like we lose current scope in the responseHandler. This PR aims to fix that.