### PR TITLE
handling path parameters via configuration mappings

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -122,7 +122,18 @@ kamon.instrumentation.http4s {
         # cases it is not possible to define an operation name right at the moment of starting the HTTP server Span
         # and in those cases, this operation name will be initially assigned to the Span. Instrumentation authors
         # should do their best effort to provide a suitable operation name or make use of the "mappings" facilities.
-        #default = "http.server.request"
+        default = "http.server.request"
+
+        # The operation name to be assigned when an application cannot find any route/endpoint/controller to handle
+        # a given request. Depending on the instrumented framework, it might be possible to apply this operation
+        # name automatically or not, check the frameworks' instrumentation docs for more details.
+        unhandled = "unhandled"
+
+        # FQCN for a HttpOperationNameGenerator implementation, or ony of the following shorthand forms:
+        #   - default: Uses the set default operation name
+        #   - method: Uses the request HTTP method as the operation name.
+        #
+        name-generator = "kamon.http4s.PathOperationNameGenerator"
 
         # Provides custom mappings from HTTP paths into operation names. Meant to be used in cases where the bytecode
         # instrumentation is not able to provide a sensible operation name that is free of high cardinality values.

--- a/src/main/scala/kamon/http4s/middleware/server/KamonSupport.scala
+++ b/src/main/scala/kamon/http4s/middleware/server/KamonSupport.scala
@@ -41,7 +41,6 @@ object KamonSupport {
                                 (implicit F: Sync[F]): OptionT[F, Response[F]] = OptionT {
     getHandler(instrumentation)(request).use { handler =>
       for {
-        _               <- setOperationName(request, handler, instrumentation.settings)
         resOrUnhandled  <- service(request).value.attempt
         respWithContext <- kamonServiceHandler(handler, resOrUnhandled, instrumentation.settings)
       } yield respWithContext
@@ -86,17 +85,5 @@ object KamonSupport {
           Some(a)
         }
     }
-
-
-  private def setOperationName[F[_]](
-                                      request: Request[F],
-                                      handler: RequestHandler,
-                                      settings: HttpServerInstrumentation.Settings)(implicit F: Sync[F]): F[Unit] =
-    F.delay {
-      val operationName = Http4s.nameGenerator
-        .name(buildRequestMessage(request))
-        .getOrElse(settings.defaultOperationName)
-      handler.span.name(operationName)
-    } *> F.unit
 
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+kamon.instrumentation.http4s.server.tracing.operations{
+      mappings {
+        "/tracing/*/ok" = "/tracing/:name/ok"
+      }
+}

--- a/src/test/scala/kamon/http4s/ServerInstrumentationSpec.scala
+++ b/src/test/scala/kamon/http4s/ServerInstrumentationSpec.scala
@@ -55,6 +55,7 @@ class ServerInstrumentationSpec extends WordSpec
           case GET -> Root / "tracing" / "ok" =>  Ok("ok")
           case GET -> Root / "tracing" / "error"  => InternalServerError("error!")
           case GET -> Root / "tracing" / "errorinternal"  => throw new RuntimeException("ble")
+          case GET -> Root / "tracing" / name / "ok" =>  Ok(s"ok $name")
         }
       ,"", 0).orNotFound)
     .resource
@@ -158,5 +159,23 @@ class ServerInstrumentationSpec extends WordSpec
       request *> test
     }
 
+    "handle path parameter" in withServerAndClient { (server, client) =>
+      val request: IO[(String, Headers)] =
+        getResponse("/tracing/bazz/ok")(server, client)
+      val test = IO {
+        eventually(timeout(5.seconds)) {
+          val span = testSpanReporter.nextSpan().value
+
+          span.operationName shouldBe "/tracing/:name/ok"
+          span.kind shouldBe Span.Kind.Server
+          span.hasError shouldBe false
+          span.metricTags.get(plain("component")) shouldBe "http4s.server"
+          span.metricTags.get(plain("http.method")) shouldBe "GET"
+          span.metricTags.get(plainLong("http.status_code")) shouldBe 200
+        }
+      }
+
+      request *> test
+    }
   }
 }


### PR DESCRIPTION
### use case

Being able to map requests to the same logical endpoint to a unique path name.

e.g.: Given the following endpoint

`GET > books/{bookId}`

and the following requests to the above endpoint

```
GET books/1
GET books/2
GET books/3
```

Rather than mapping each of them to a different path, it could be useful to map all of them to the same logical path, so that the same metric could collect different requests, under the same logical path 

`GET > books/{bookId}`