### PR TITLE
Don't change operation name for not-found

### DIFF
--- a/src/test/scala/kamon/http4s/ClientInstrumentationSpec.scala
+++ b/src/test/scala/kamon/http4s/ClientInstrumentationSpec.scala
@@ -104,8 +104,7 @@ class ClientInstrumentationSpec extends WordSpec
 
       eventually(timeout(2 seconds)) {
         val span = testSpanReporter().nextSpan().value
-        //TODO what should be client not found oper name, settings provide no default for clients
-        span.operationName shouldBe "http.client.request"
+        span.operationName shouldBe "/tracing/not-found"
         span.kind shouldBe Span.Kind.Client
         span.metricTags.get(plain("component")) shouldBe "http4s.client"
         span.metricTags.get(plain("http.method")) shouldBe "GET"


### PR DESCRIPTION
As far as I can tell, the current behaviour seems to be a hangover from the pre-Kamon-2.x naming/tagging schemes. 