### PR TITLE
Kamon 2.2.x, http4s 0.22

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,9 +17,9 @@ val kamonCore         = "io.kamon"    %% "kamon-core"                     % "2.2
 val kamonTestkit      = "io.kamon"    %% "kamon-testkit"                  % "2.2.2"
 val kamonCommon       = "io.kamon"    %% "kamon-instrumentation-common"   % "2.2.2"
 
-val server            = "org.http4s"  %%  "http4s-blaze-server"   % "0.22.0-RC1"
-val client            = "org.http4s"  %%  "http4s-blaze-client"   % "0.22.0-RC1"
-val dsl               = "org.http4s"  %%  "http4s-dsl"            % "0.22.0-RC1"
+val server            = "org.http4s"  %%  "http4s-blaze-server"   % "0.22.0"
+val client            = "org.http4s"  %%  "http4s-blaze-client"   % "0.22.0"
+val dsl               = "org.http4s"  %%  "http4s-dsl"            % "0.22.0"
 
 
 lazy val root = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -13,20 +13,20 @@
  * =========================================================================================
  */
 
-val kamonCore         = "io.kamon"    %% "kamon-core"                     % "2.1.0"
-val kamonTestkit      = "io.kamon"    %% "kamon-testkit"                  % "2.1.0"
-val kamonCommon       = "io.kamon"    %% "kamon-instrumentation-common"   % "2.1.0"
+val kamonCore         = "io.kamon"    %% "kamon-core"                     % "2.2.2"
+val kamonTestkit      = "io.kamon"    %% "kamon-testkit"                  % "2.2.2"
+val kamonCommon       = "io.kamon"    %% "kamon-instrumentation-common"   % "2.2.2"
 
-val server            = "org.http4s"  %%  "http4s-blaze-server"   % "0.21.3"
-val client            = "org.http4s"  %%  "http4s-blaze-client"   % "0.21.3"
-val dsl               = "org.http4s"  %%  "http4s-dsl"            % "0.21.3"
+val server            = "org.http4s"  %%  "http4s-blaze-server"   % "0.22.0-RC1"
+val client            = "org.http4s"  %%  "http4s-blaze-client"   % "0.22.0-RC1"
+val dsl               = "org.http4s"  %%  "http4s-dsl"            % "0.22.0-RC1"
 
 
 lazy val root = (project in file("."))
   .settings(Seq(
       name := "kamon-http4s",
-      scalaVersion := "2.13.1",
-      crossScalaVersions := Seq("2.12.11", "2.13.1")))
+      scalaVersion := "2.13.6",
+      crossScalaVersions := Seq("2.12.14", "2.13.6")))
   .settings(resolvers += Resolver.bintrayRepo("kamon-io", "snapshots"))
   .settings(resolvers += Resolver.mavenLocal)
   .settings(scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.5.5

--- a/src/main/scala/kamon/http4s/middleware/client/KamonSupport.scala
+++ b/src/main/scala/kamon/http4s/middleware/client/KamonSupport.scala
@@ -42,7 +42,7 @@ object KamonSupport {
   def apply[F[_]](underlying: Client[F])(implicit F:Sync[F]): Client[F] = Client { request =>
 
     for {
-      ctx <- Resource.liftF(F.delay(Kamon.currentContext()))
+      ctx <- Resource.eval(F.delay(Kamon.currentContext()))
       k   <- kamonClient(underlying)(request)(ctx)(_instrumentation)
     } yield k
   }
@@ -54,9 +54,9 @@ object KamonSupport {
                                (instrumentation: HttpClientInstrumentation)
                                (implicit F:Sync[F]): Resource[F, Response[F]] =
     for {
-      requestHandler  <- Resource.liftF(F.delay(instrumentation.createHandler(getRequestBuilder(request), ctx)))
+      requestHandler  <- Resource.eval(F.delay(instrumentation.createHandler(getRequestBuilder(request), ctx)))
       response        <- underlying.run(requestHandler.request).attempt
-      trackedResponse <- Resource.liftF(handleResponse(response, requestHandler))
+      trackedResponse <- Resource.eval(handleResponse(response, requestHandler))
     } yield trackedResponse
 
   def handleResponse[F[_]](

--- a/src/main/scala/kamon/http4s/middleware/server/KamonSupport.scala
+++ b/src/main/scala/kamon/http4s/middleware/server/KamonSupport.scala
@@ -56,7 +56,7 @@ object KamonSupport {
 
   private def getHandler[F[_]](instrumentation: HttpServerInstrumentation)(request: Request[F])(implicit F: Sync[F]): Resource[F, RequestHandler] =
     for {
-      handler <- Resource.liftF(F.delay(instrumentation.createHandler(buildRequestMessage(request))))
+      handler <- Resource.eval(F.delay(instrumentation.createHandler(buildRequestMessage(request))))
       _       <- processRequest(handler)
       _       <- withContext(handler)
     } yield handler

--- a/src/main/scala/kamon/http4s/package.scala
+++ b/src/main/scala/kamon/http4s/package.scala
@@ -3,7 +3,7 @@ package kamon
 import org.http4s.{Header, Headers, Request, Response, Status}
 import kamon.instrumentation.http.HttpMessage
 import kamon.instrumentation.http.HttpMessage.ResponseBuilder
-import org.http4s.util.CaseInsensitiveString
+import org.typelevel.ci.CIString
 
 package object http4s {
 
@@ -11,7 +11,7 @@ package object http4s {
   def buildRequestMessage[F[_]](inner: Request[F]): HttpMessage.Request = new HttpMessage.Request {
     override def url: String = inner.uri.toString()
 
-    override def path: String = inner.uri.path
+    override def path: String = inner.uri.path.renderString
 
     override def method: String = inner.method.name
 
@@ -19,11 +19,11 @@ package object http4s {
 
     override def port: Int = inner.uri.authority.flatMap(_.port).getOrElse(0)
 
-    override def read(header: String): Option[String] = inner.headers.get(CaseInsensitiveString(header)).map(_.value)
+    override def read(header: String): Option[String] = inner.headers.get(CIString(header)).map(_.head.value)
 
     override def readAll(): Map[String, String] = {
       val builder = Map.newBuilder[String, String]
-      inner.headers.foreach(h => builder += (h.name.value -> h.value))
+      inner.headers.foreach(h => builder += (h.name.toString -> h.value))
       builder.result()
     }
   }
@@ -31,7 +31,7 @@ package object http4s {
   def errorResponseBuilder[F[_]]: HttpMessage.ResponseBuilder[Response[F]] = new ResponseBuilder[Response[F]] {
     override def write(header: String, value: String): Unit = ()
     override def statusCode: Int = 500
-    override def build(): Response[F] = new Response[F](status = Status.InternalServerError)
+    override def build(): Response[F] = Response[F](status = Status.InternalServerError)
   }
 
   //TODO both of these
@@ -39,13 +39,13 @@ package object http4s {
     private var _headers = Headers.empty
 
     override def write(header: String, value: String): Unit =
-      _headers = _headers.put(Header(header, value))
+      _headers = _headers.put(Header.Raw(CIString(header), value))
 
     override def statusCode: Int = 404
-    override def build(): Response[F] = new Response[F](status = Status.NotFound, headers = _headers)
+    override def build(): Response[F] = Response[F](status = Status.NotFound, headers = _headers)
   }
 
-  def getResponseBuilder[F[_]](response: Response[F]) = new HttpMessage.ResponseBuilder[Response[F]] {
+  def getResponseBuilder[F[_]](response: Response[F]): ResponseBuilder[Response[F]] = new HttpMessage.ResponseBuilder[Response[F]] {
     private var _headers = response.headers
 
     override def statusCode: Int = response.status.code
@@ -53,7 +53,7 @@ package object http4s {
     override def build(): Response[F] = response.withHeaders(_headers)
 
     override def write(header: String, value: String): Unit =
-      _headers = _headers.put(Header(header, value))
+      _headers = _headers.put(Header.Raw(CIString(header), value))
   }
 
 
@@ -63,11 +63,11 @@ package object http4s {
     override def build(): Request[F] = request.withHeaders(_headers)
 
     override def write(header: String, value: String): Unit =
-      _headers = _headers.put(Header(header, value))
+      _headers = _headers.put(Header.Raw(CIString(header), value))
 
     override def url: String = request.uri.toString()
 
-    override def path: String = request.uri.path
+    override def path: String = request.uri.path.renderString
 
     override def method: String = request.method.name
 
@@ -75,11 +75,11 @@ package object http4s {
 
     override def port: Int = request.uri.authority.flatMap(_.port).getOrElse(0)
 
-    override def read(header: String): Option[String] = _headers.get(CaseInsensitiveString(header)).map(_.value)
+    override def read(header: String): Option[String] = _headers.get(CIString(header)).map(_.head.value)
 
     override def readAll(): Map[String, String] = {
       val builder = Map.newBuilder[String, String]
-      request.headers.foreach(h => builder += (h.name.value -> h.value))
+      request.headers.foreach(h => builder += (h.name.toString -> h.value))
       builder.result()
     }
   }

--- a/src/test/scala/kamon/http4s/ClientInstrumentationSpec.scala
+++ b/src/test/scala/kamon/http4s/ClientInstrumentationSpec.scala
@@ -74,7 +74,7 @@ class ClientInstrumentationSpec extends WordSpec
     "close and finish a span even if an exception is thrown by the client" in {
       val okSpan = Kamon.spanBuilder("client-exception").start()
       val client: Client[IO] = KamonSupport[IO](
-        Client(_ => Resource.liftF(IO.raiseError[Response[IO]](new ConnectException("Connection Refused."))))
+        Client(_ => Resource.eval(IO.raiseError[Response[IO]](new ConnectException("Connection Refused."))))
       )
 
       Kamon.runWithSpan(okSpan) {

--- a/src/test/scala/kamon/http4s/HttpMetricsSpec.scala
+++ b/src/test/scala/kamon/http4s/HttpMetricsSpec.scala
@@ -88,7 +88,7 @@ class HttpMetricsSpec extends WordSpec
     "track the response time with status code 2xx" in withServerAndClient { (server, client, serverMetrics) =>
       val requests: IO[Unit] = List.fill(100)(get("/tracing/ok")(server, client)).sequence_
 
-      val test = IO(serverMetrics.requestsSuccessful.value should be >= 0L)
+      val test = IO(serverMetrics.requestsSuccessful.value() should be >= 0L)
 
       requests *> test
     }
@@ -96,7 +96,7 @@ class HttpMetricsSpec extends WordSpec
     "track the response time with status code 4xx" in withServerAndClient { (server, client, serverMetrics) =>
       val requests: IO[Unit] = List.fill(100)(get("/tracing/not-found")(server, client).attempt).sequence_
 
-      val test = IO(serverMetrics.requestsClientError.value should be >= 0L)
+      val test = IO(serverMetrics.requestsClientError.value() should be >= 0L)
 
       requests *> test
     }
@@ -104,7 +104,7 @@ class HttpMetricsSpec extends WordSpec
     "track the response time with status code 5xx" in withServerAndClient { (server, client, serverMetrics) =>
       val requests: IO[Unit] = List.fill(100)(get("/tracing/error")(server, client).attempt).sequence_
 
-      val test = IO(serverMetrics.requestsServerError.value should be >= 0L)
+      val test = IO(serverMetrics.requestsServerError.value() should be >= 0L)
 
       requests *> test
     }

--- a/src/test/scala/kamon/http4s/ServerInstrumentationSpec.scala
+++ b/src/test/scala/kamon/http4s/ServerInstrumentationSpec.scala
@@ -17,24 +17,24 @@
 package kamon.http4s
 
 import cats.effect.{ContextShift, IO, Sync, Timer}
+import cats.implicits._
 import kamon.http4s.middleware.server.KamonSupport
+import kamon.tag.Lookups.{plain, plainLong}
+import kamon.testkit.TestSpanReporter
 import kamon.trace.Span
-import org.http4s.{Headers, HttpRoutes}
+import org.http4s.blaze.client.BlazeClientBuilder
+import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.client.Client
-import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.dsl.io._
-import org.http4s.server.{Server}
-import org.http4s.server.blaze.BlazeServerBuilder
+import org.http4s.implicits._
+import org.http4s.server.Server
+import org.http4s.{Headers, HttpRoutes}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.SpanSugar
 import org.scalatest.{BeforeAndAfterAll, Matchers, OptionValues, WordSpec}
+import org.typelevel.ci.CIString
 
 import scala.concurrent.ExecutionContext
-import org.http4s.implicits._
-import cats.implicits._
-import kamon.testkit.TestSpanReporter
-import kamon.tag.Lookups.{plain, plainLong}
-import org.http4s.util.CaseInsensitiveString
 
 class ServerInstrumentationSpec extends WordSpec
   with Matchers
@@ -48,9 +48,8 @@ class ServerInstrumentationSpec extends WordSpec
   implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
 
   val srv =
-    BlazeServerBuilder[IO]
+    BlazeServerBuilder[IO](ExecutionContext.global)
       .bindAny()
-      .withExecutionContext(ExecutionContext.global)
       .withHttpApp(KamonSupport(HttpRoutes.of[IO] {
           case GET -> Root / "tracing" / "ok" =>  Ok("ok")
           case GET -> Root / "tracing" / "error"  => InternalServerError("error!")
@@ -63,19 +62,19 @@ class ServerInstrumentationSpec extends WordSpec
   val client =
     BlazeClientBuilder[IO](ExecutionContext.global).resource
 
-  def withServerAndClient[A](f: (Server[IO], Client[IO]) => IO[A]): A =
+  def withServerAndClient[A](f: (Server, Client[IO]) => IO[A]): A =
     (srv, client).tupled.use(f.tupled).unsafeRunSync()
 
-  private def getResponse[F[_]: Sync](path: String)(server: Server[F], client: Client[F]): F[(String, Headers)] = {
-    client.get(s"http://127.0.0.1:${server.address.getPort}$path"){ r =>
-      r.bodyAsText.compile.toList.map(_.mkString).map(_ -> r.headers)
+  private def getResponse[F[_]: Sync](path: String)(server: Server, client: Client[F]): F[(String, Headers)] = {
+    client.get(s"http://127.0.0.1:${server.address.getPort}$path") { r =>
+      r.bodyText.compile.toList.map(_.mkString).map(_ -> r.headers)
     }
   }
 
   "The Server instrumentation" should {
     "propagate the current context and respond to the ok action" in withServerAndClient { (server, client) =>
       val request = getResponse("/tracing/ok")(server, client).map { case (body, headers) =>
-        headers.exists(_.name == CaseInsensitiveString("trace-id")) shouldBe true
+        headers.get(CIString("trace-id")).nonEmpty shouldBe true
         body should startWith("ok")
       }
 
@@ -96,12 +95,12 @@ class ServerInstrumentationSpec extends WordSpec
 
     "propagate the current context and respond to the not-found action" in withServerAndClient { (server, client) =>
       val request = getResponse("/tracing/not-found")(server, client).map { case (body, headers) =>
-        headers.exists(_.name == CaseInsensitiveString("trace-id")) shouldBe true
+        headers.get(CIString("trace-id")).nonEmpty shouldBe true
       }
 
       val test = IO {
         eventually(timeout(5.seconds)) {
-          val span = testSpanReporter.nextSpan().value
+          val span = testSpanReporter().nextSpan().value
 
           span.operationName shouldBe "unhandled"
           span.kind shouldBe Span.Kind.Server
@@ -116,13 +115,13 @@ class ServerInstrumentationSpec extends WordSpec
 
     "propagate the current context and respond to the error action" in withServerAndClient { (server, client) =>
       val request = getResponse("/tracing/error")(server, client).map { case (body, headers) =>
-        headers.exists(_.name == CaseInsensitiveString("trace-id")) shouldBe true
+        headers.get(CIString("trace-id")).nonEmpty shouldBe true
         body should startWith("error!")
       }
 
       val test = IO {
         eventually(timeout(5.seconds)) {
-          val span = testSpanReporter.nextSpan().value
+          val span = testSpanReporter().nextSpan().value
 
           span.operationName shouldBe "/tracing/error"
           span.kind shouldBe Span.Kind.Server
@@ -139,13 +138,13 @@ class ServerInstrumentationSpec extends WordSpec
       val request = getResponse("/tracing/errorinternal")(server, client)
       /* TODO serviceErrorHandler kicks in and rewrites response, loosing trace information
         .map { case (body, headers) =>
-          headers.exists(_.name == CaseInsensitiveString("trace-id")) shouldBe true
+          headers.get(CIString("trace-id")).nonEmpty shouldBe true
         }
       */
 
       val test = IO {
         eventually(timeout(5.seconds)) {
-          val span = testSpanReporter.nextSpan().value
+          val span = testSpanReporter().nextSpan().value
 
           span.operationName shouldBe "/tracing/errorinternal"
           span.kind shouldBe Span.Kind.Server
@@ -164,7 +163,7 @@ class ServerInstrumentationSpec extends WordSpec
         getResponse("/tracing/bazz/ok")(server, client)
       val test = IO {
         eventually(timeout(5.seconds)) {
-          val span = testSpanReporter.nextSpan().value
+          val span = testSpanReporter().nextSpan().value
 
           span.operationName shouldBe "/tracing/:name/ok"
           span.kind shouldBe Span.Kind.Server


### PR DESCRIPTION
Hello,

As http4s moves to 0.22, 0.23 and 1.0 in parallel, would it be possible to publish multiple versions of the kamon-http4s integration?

The upgrade to 0.22 is fairly small (mostly headers, see diffs) but Cats Effect 3 (for 0.23 and 1.0) makes `ClientInstrumentationSpec` fail and I couldn't figure out why (I'm not familiar with CE3 yet).

I hope this helps.