### PR TITLE
Fix module name of published artifacts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,12 +22,13 @@ def http4sDeps(version: String) = Seq(
   "org.http4s" %% "http4s-server"       % version % Provided,
   "org.http4s" %% "http4s-blaze-client" % version % Test,
   "org.http4s" %% "http4s-blaze-server" % version % Test,
-  "org.http4s" %% "http4s-dsl"          % version % Test2
+  "org.http4s" %% "http4s-dsl"          % version % Test
 )
 
 lazy val shared = Seq(
   scalaVersion := "2.13.6",
   crossScalaVersions := Seq("2.12.14", "2.13.6"),
+  moduleName := name.value,
   publishTo := sonatypePublishToBundle.value,
   scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, 12)) => Seq("-Ypartial-unification", "-language:higherKinds")
@@ -43,7 +44,7 @@ lazy val `kamon-http4s-0_22` = project
   .settings(
     shared,
     name := "kamon-http4s-0.22",
-    libraryDependencies ++= http4sDeps("0.22.1")
+    libraryDependencies ++= http4sDeps("0.22.2")
   )
 
 lazy val `kamon-http4s-0_23` = project
@@ -51,7 +52,7 @@ lazy val `kamon-http4s-0_23` = project
   .settings(
     shared,
     name := "kamon-http4s-0.23",
-    libraryDependencies ++= http4sDeps("0.23.0")
+    libraryDependencies ++= http4sDeps("0.23.1")
   )
 
 lazy val `kamon-http4s-1_0` = project
@@ -59,7 +60,7 @@ lazy val `kamon-http4s-1_0` = project
   .settings(
     shared,
     name := "kamon-http4s-1.0",
-    libraryDependencies ++= http4sDeps("1.0.0-M23")
+    libraryDependencies ++= http4sDeps("1.0.0-M24")
   )
 
 lazy val root = project

--- a/modules/1.0/src/test/scala/kamon/http4s/HttpMetricsSpec.scala
+++ b/modules/1.0/src/test/scala/kamon/http4s/HttpMetricsSpec.scala
@@ -62,7 +62,7 @@ class HttpMetricsSpec extends WordSpec
    (srv, client, metrics).tupled.use(f.tupled).unsafeRunSync()
 
   private def get[F[_]: Concurrent](path: String)(server: Server, client: Client[F]): F[String] = {
-    client.expect[String](s"http://127.0.0.1:${server.address.getPort}$path")
+    client.expect[String](s"http://127.0.0.1:${server.address.port}$path")
   }
 
   "The HttpMetrics" should {

--- a/modules/1.0/src/test/scala/kamon/http4s/ServerInstrumentationSpec.scala
+++ b/modules/1.0/src/test/scala/kamon/http4s/ServerInstrumentationSpec.scala
@@ -61,7 +61,7 @@ class ServerInstrumentationSpec extends WordSpec
     (srv, client).tupled.use(f.tupled).unsafeRunSync()
 
   private def getResponse[F[_]: Concurrent](path: String)(server: Server, client: Client[F]): F[(String, Headers)] = {
-    client.get(s"http://127.0.0.1:${server.address.getPort}$path") { r =>
+    client.get(s"http://127.0.0.1:${server.address.port}$path") { r =>
       r.bodyText.compile.toList.map(_.mkString).map(_ -> r.headers)
     }
   }


### PR DESCRIPTION
Hello,

I hadn't realized sbt turns dots into hyphens in the name of published artifacts.
This should fix the issue.