### PR TITLE
Allowing to configure the component name for the http4s client metrics

### DIFF
--- a/modules/0.22/src/test/scala/kamon/http4s/ClientInstrumentationSpec.scala
+++ b/modules/0.22/src/test/scala/kamon/http4s/ClientInstrumentationSpec.scala
@@ -51,7 +51,10 @@ class ClientInstrumentationSpec
   }
 
   val client: Client[IO] =
-    KamonSupport[IO](Client.fromHttpApp[IO](service.orNotFound))
+    KamonSupport[IO](
+      Client.fromHttpApp[IO](service.orNotFound),
+      "my-service-name"
+    )
 
   "The Client instrumentation" should {
     "propagate the current context and generate a span inside an action and complete the ws request" in {
@@ -66,7 +69,7 @@ class ClientInstrumentationSpec
 
         span.operationName shouldBe "/tracing/ok"
         span.kind shouldBe Span.Kind.Client
-        span.metricTags.get(plain("component")) shouldBe "http4s.client"
+        span.metricTags.get(plain("component")) shouldBe "my-service-name"
         span.metricTags.get(plain("http.method")) shouldBe "GET"
         span.metricTags.get(plainLong("http.status_code")) shouldBe 200
         span.metricTags.get(
@@ -99,7 +102,7 @@ class ClientInstrumentationSpec
         val span = testSpanReporter().nextSpan().value
         span.operationName shouldBe "/tracing/ok"
         span.kind shouldBe Span.Kind.Client
-        span.metricTags.get(plain("component")) shouldBe "http4s.client"
+        span.metricTags.get(plain("component")) shouldBe "my-service-name"
         span.metricTags.get(plain("http.method")) shouldBe "GET"
         span.hasError shouldBe true
 
@@ -122,7 +125,7 @@ class ClientInstrumentationSpec
         val span = testSpanReporter().nextSpan().value
         span.operationName shouldBe "/tracing/not-found"
         span.kind shouldBe Span.Kind.Client
-        span.metricTags.get(plain("component")) shouldBe "http4s.client"
+        span.metricTags.get(plain("component")) shouldBe "my-service-name"
         span.metricTags.get(plain("http.method")) shouldBe "GET"
         span.metricTags.get(plainLong("http.status_code")) shouldBe 404
         span.metricTags.get(
@@ -149,7 +152,7 @@ class ClientInstrumentationSpec
 
         span.operationName shouldBe "/tracing/error"
         span.kind shouldBe Span.Kind.Client
-        span.metricTags.get(plain("component")) shouldBe "http4s.client"
+        span.metricTags.get(plain("component")) shouldBe "my-service-name"
         span.metricTags.get(plain("http.method")) shouldBe "GET"
         span.hasError shouldBe true
         span.metricTags.get(plainLong("http.status_code")) shouldBe 500

--- a/modules/0.23/src/test/scala/kamon/http4s/ClientInstrumentationSpec.scala
+++ b/modules/0.23/src/test/scala/kamon/http4s/ClientInstrumentationSpec.scala
@@ -52,7 +52,10 @@ class ClientInstrumentationSpec
   }
 
   val client: Client[IO] =
-    KamonSupport[IO](Client.fromHttpApp[IO](service.orNotFound))
+    KamonSupport[IO](
+      Client.fromHttpApp[IO](service.orNotFound),
+      "my-service-name"
+    )
 
   "The Client instrumentation" should {
     "propagate the current context and generate a span inside an action and complete the ws request" in {
@@ -67,7 +70,7 @@ class ClientInstrumentationSpec
 
         span.operationName shouldBe "/tracing/ok"
         span.kind shouldBe Span.Kind.Client
-        span.metricTags.get(plain("component")) shouldBe "http4s.client"
+        span.metricTags.get(plain("component")) shouldBe "my-service-name"
         span.metricTags.get(plain("http.method")) shouldBe "GET"
         span.metricTags.get(plainLong("http.status_code")) shouldBe 200
         span.metricTags.get(
@@ -100,7 +103,7 @@ class ClientInstrumentationSpec
         val span = testSpanReporter().nextSpan().value
         span.operationName shouldBe "/tracing/ok"
         span.kind shouldBe Span.Kind.Client
-        span.metricTags.get(plain("component")) shouldBe "http4s.client"
+        span.metricTags.get(plain("component")) shouldBe "my-service-name"
         span.metricTags.get(plain("http.method")) shouldBe "GET"
         span.hasError shouldBe true
 
@@ -123,7 +126,7 @@ class ClientInstrumentationSpec
         val span = testSpanReporter().nextSpan().value
         span.operationName shouldBe "/tracing/not-found"
         span.kind shouldBe Span.Kind.Client
-        span.metricTags.get(plain("component")) shouldBe "http4s.client"
+        span.metricTags.get(plain("component")) shouldBe "my-service-name"
         span.metricTags.get(plain("http.method")) shouldBe "GET"
         span.metricTags.get(plainLong("http.status_code")) shouldBe 404
         span.metricTags.get(
@@ -150,7 +153,7 @@ class ClientInstrumentationSpec
 
         span.operationName shouldBe "/tracing/error"
         span.kind shouldBe Span.Kind.Client
-        span.metricTags.get(plain("component")) shouldBe "http4s.client"
+        span.metricTags.get(plain("component")) shouldBe "my-service-name"
         span.metricTags.get(plain("http.method")) shouldBe "GET"
         span.hasError shouldBe true
         span.metricTags.get(plainLong("http.status_code")) shouldBe 500

--- a/modules/1.0/src/test/scala/kamon/http4s/ClientInstrumentationSpec.scala
+++ b/modules/1.0/src/test/scala/kamon/http4s/ClientInstrumentationSpec.scala
@@ -52,7 +52,10 @@ class ClientInstrumentationSpec
   }
 
   val client: Client[IO] =
-    KamonSupport[IO](Client.fromHttpApp[IO](service.orNotFound))
+    KamonSupport[IO](
+      Client.fromHttpApp[IO](service.orNotFound),
+      "my-service-name"
+    )
 
   "The Client instrumentation" should {
     "propagate the current context and generate a span inside an action and complete the ws request" in {
@@ -67,7 +70,7 @@ class ClientInstrumentationSpec
 
         span.operationName shouldBe "/tracing/ok"
         span.kind shouldBe Span.Kind.Client
-        span.metricTags.get(plain("component")) shouldBe "http4s.client"
+        span.metricTags.get(plain("component")) shouldBe "my-service-name"
         span.metricTags.get(plain("http.method")) shouldBe "GET"
         span.metricTags.get(plainLong("http.status_code")) shouldBe 200
         span.metricTags.get(
@@ -100,7 +103,7 @@ class ClientInstrumentationSpec
         val span = testSpanReporter().nextSpan().value
         span.operationName shouldBe "/tracing/ok"
         span.kind shouldBe Span.Kind.Client
-        span.metricTags.get(plain("component")) shouldBe "http4s.client"
+        span.metricTags.get(plain("component")) shouldBe "my-service-name"
         span.metricTags.get(plain("http.method")) shouldBe "GET"
         span.hasError shouldBe true
 
@@ -123,7 +126,7 @@ class ClientInstrumentationSpec
         val span = testSpanReporter().nextSpan().value
         span.operationName shouldBe "/tracing/not-found"
         span.kind shouldBe Span.Kind.Client
-        span.metricTags.get(plain("component")) shouldBe "http4s.client"
+        span.metricTags.get(plain("component")) shouldBe "my-service-name"
         span.metricTags.get(plain("http.method")) shouldBe "GET"
         span.metricTags.get(plainLong("http.status_code")) shouldBe 404
         span.metricTags.get(
@@ -150,7 +153,7 @@ class ClientInstrumentationSpec
 
         span.operationName shouldBe "/tracing/error"
         span.kind shouldBe Span.Kind.Client
-        span.metricTags.get(plain("component")) shouldBe "http4s.client"
+        span.metricTags.get(plain("component")) shouldBe "my-service-name"
         span.metricTags.get(plain("http.method")) shouldBe "GET"
         span.hasError shouldBe true
         span.metricTags.get(plainLong("http.status_code")) shouldBe 500


### PR DESCRIPTION
At the moment all the client metrics are generated with component name `http4s.client`, in my use case I need to have more specific names for them.

Considering the following example:

1. I have service A that is performing calls to services B C D
2. I have service B that is performing calls to service F
3. I have service C that is performing calls to service F

What I would like to achieve is to have inside the metrics the information regarding which service (component) is the metric about.